### PR TITLE
Fix datagram length check and middleware execution

### DIFF
--- a/option.go
+++ b/option.go
@@ -136,15 +136,15 @@ type MiddlewareChain []Middleware
 
 // Execute is used to add interceptors in chain
 func (m MiddlewareChain) Execute(ctx context.Context, writer io.Writer, request *Request, last Handler) error {
-	if len(m) == 0 {
-		return nil
-	}
 	for i := 0; i < len(m); i++ {
 		if err := m[i](ctx, writer, request); err != nil {
 			return err
 		}
 	}
-	return last(ctx, writer, request)
+	if last != nil {
+		return last(ctx, writer, request)
+	}
+	return nil
 }
 
 // WithConnectMiddleware is used to add interceptors in chain

--- a/statute/datagram.go
+++ b/statute/datagram.go
@@ -56,7 +56,7 @@ func ParseDatagram(b []byte) (da Datagram, err error) {
 		da.DstAddr.Port = int(binary.BigEndian.Uint16((b[headLen-2:])))
 	case ATYPIPv6:
 		headLen += net.IPv6len + 2
-		if len(b) <= headLen {
+		if len(b) < headLen {
 			err = errors.New("datagram to short")
 			return
 		}
@@ -66,7 +66,7 @@ func ParseDatagram(b []byte) (da Datagram, err error) {
 	case ATYPDomain:
 		addrLen := int(b[4])
 		headLen += 1 + addrLen + 2
-		if len(b) <= headLen {
+		if len(b) < headLen {
 			err = errors.New("datagram to short")
 			return
 		}


### PR DESCRIPTION
## Summary
- fix datagram length comparison so empty UDP payloads are allowed
- ensure middleware chains run the final handler even when no middleware is present

## Testing
- `go test ./...` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_684c365b4f28832aab219aae4a0710cd