### PR TITLE
Refactor into smaller packages

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,4 +1,4 @@
-package socks5
+package auth
 
 import (
 	"io"

--- a/auth/credentials.go
+++ b/auth/credentials.go
@@ -1,4 +1,4 @@
-package socks5
+package auth
 
 // CredentialStore is used to support user/pass authentication optional network addr
 // if you want to limit user network addr,you can refuse it.

--- a/auth_test.go
+++ b/auth_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/things-go/go-socks5/auth"
 	"github.com/things-go/go-socks5/statute"
 )
 
 func TestNoAuth(t *testing.T) {
 	req := bytes.NewBuffer(nil)
 	rsp := new(bytes.Buffer)
-	cator := NoAuthAuthenticator{}
+	cator := auth.NoAuthAuthenticator{}
 
 	ctx, err := cator.Authenticate(req, rsp, "")
 	require.NoError(t, err)
@@ -25,8 +26,8 @@ func TestNoAuth(t *testing.T) {
 func TestPasswordAuth_Valid(t *testing.T) {
 	req := bytes.NewBuffer([]byte{1, 3, 'f', 'o', 'o', 3, 'b', 'a', 'r'})
 	rsp := new(bytes.Buffer)
-	cator := UserPassAuthenticator{
-		StaticCredentials{
+	cator := auth.UserPassAuthenticator{
+		Credentials: auth.StaticCredentials{
 			"foo": "bar",
 		},
 	}
@@ -49,8 +50,8 @@ func TestPasswordAuth_Valid(t *testing.T) {
 func TestPasswordAuth_Invalid(t *testing.T) {
 	req := bytes.NewBuffer([]byte{1, 3, 'f', 'o', 'o', 3, 'b', 'a', 'z'})
 	rsp := new(bytes.Buffer)
-	cator := UserPassAuthenticator{
-		StaticCredentials{
+	cator := auth.UserPassAuthenticator{
+		Credentials: auth.StaticCredentials{
 			"foo": "bar",
 		},
 	}

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/things-go/go-socks5/auth"
 )
 
 func TestStaticCredentials(t *testing.T) {
-	creds := StaticCredentials{
+	creds := auth.StaticCredentials{
 		"foo": "bar",
 		"baz": "",
 	}

--- a/handle.go
+++ b/handle.go
@@ -9,46 +9,12 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/things-go/go-socks5/handler"
 	"github.com/things-go/go-socks5/statute"
 )
 
-// AddressRewriter is used to rewrite a destination transparently
-type AddressRewriter interface {
-	Rewrite(ctx context.Context, request *Request) (context.Context, *statute.AddrSpec)
-}
-
-// A Request represents request received by a server
-type Request struct {
-	statute.Request
-	// AuthContext provided during negotiation
-	AuthContext *AuthContext
-	// LocalAddr of the network server listen
-	LocalAddr net.Addr
-	// RemoteAddr of the network that sent the request
-	RemoteAddr net.Addr
-	// DestAddr of the actual destination (might be affected by rewrite)
-	DestAddr *statute.AddrSpec
-	// Reader connect of request
-	Reader io.Reader
-	// RawDestAddr of the desired destination
-	RawDestAddr *statute.AddrSpec
-}
-
-// ParseRequest creates a new Request from the tcp connection
-func ParseRequest(bufConn io.Reader) (*Request, error) {
-	hd, err := statute.ParseRequest(bufConn)
-	if err != nil {
-		return nil, err
-	}
-	return &Request{
-		Request:     hd,
-		RawDestAddr: &hd.DstAddr,
-		Reader:      bufConn,
-	}, nil
-}
-
 // handleRequest is used for request processing after authentication
-func (sf *Server) handleRequest(write io.Writer, req *Request) error {
+func (sf *Server) handleRequest(write io.Writer, req *handler.Request) error {
 	var err error
 
 	ctx := context.Background()
@@ -57,7 +23,7 @@ func (sf *Server) handleRequest(write io.Writer, req *Request) error {
 	if dest.FQDN != "" {
 		ctx, dest.IP, err = sf.resolver.Resolve(ctx, dest.FQDN)
 		if err != nil {
-			if err := SendReply(write, statute.RepHostUnreachable, nil); err != nil {
+			if err := handler.SendReply(write, statute.RepHostUnreachable, nil); err != nil {
 				return fmt.Errorf("failed to send reply, %v", err)
 			}
 			return fmt.Errorf("failed to resolve destination[%v], %v", dest.FQDN, err)
@@ -74,7 +40,7 @@ func (sf *Server) handleRequest(write io.Writer, req *Request) error {
 	var ok bool
 	ctx, ok = sf.rules.Allow(ctx, req)
 	if !ok {
-		if err := SendReply(write, statute.RepRuleFailure, nil); err != nil {
+		if err := handler.SendReply(write, statute.RepRuleFailure, nil); err != nil {
 			return fmt.Errorf("failed to send reply, %v", err)
 		}
 		return fmt.Errorf("bind to %v blocked by rules", req.RawDestAddr)
@@ -108,7 +74,7 @@ func (sf *Server) handleRequest(write io.Writer, req *Request) error {
 			return sf.userAssociateMiddlewares.Execute(ctx, write, req, last)
 		}
 	default:
-		if err := SendReply(write, statute.RepCommandNotSupported, nil); err != nil {
+		if err := handler.SendReply(write, statute.RepCommandNotSupported, nil); err != nil {
 			return fmt.Errorf("failed to send reply, %v", err)
 		}
 		return fmt.Errorf("unsupported command[%v]", req.Command)
@@ -117,7 +83,7 @@ func (sf *Server) handleRequest(write io.Writer, req *Request) error {
 }
 
 // handleConnect is used to handle a connect command
-func (sf *Server) handleConnect(ctx context.Context, writer io.Writer, request *Request) error {
+func (sf *Server) handleConnect(ctx context.Context, writer io.Writer, request *handler.Request) error {
 	// Attempt to connect
 	var target net.Conn
 	var err error
@@ -141,7 +107,7 @@ func (sf *Server) handleConnect(ctx context.Context, writer io.Writer, request *
 		} else if strings.Contains(msg, "network is unreachable") {
 			resp = statute.RepNetworkUnreachable
 		}
-		if err := SendReply(writer, resp, nil); err != nil {
+		if err := handler.SendReply(writer, resp, nil); err != nil {
 			return fmt.Errorf("failed to send reply, %v", err)
 		}
 		return fmt.Errorf("connect to %v failed, %v", request.RawDestAddr, err)
@@ -149,7 +115,7 @@ func (sf *Server) handleConnect(ctx context.Context, writer io.Writer, request *
 	defer target.Close() // nolint: errcheck
 
 	// Send success
-	if err := SendReply(writer, statute.RepSuccess, target.LocalAddr()); err != nil {
+	if err := handler.SendReply(writer, statute.RepSuccess, target.LocalAddr()); err != nil {
 		return fmt.Errorf("failed to send reply, %v", err)
 	}
 
@@ -169,16 +135,16 @@ func (sf *Server) handleConnect(ctx context.Context, writer io.Writer, request *
 }
 
 // handleBind is used to handle a connect command
-func (sf *Server) handleBind(_ context.Context, writer io.Writer, _ *Request) error {
+func (sf *Server) handleBind(_ context.Context, writer io.Writer, _ *handler.Request) error {
 	// TODO: Support bind
-	if err := SendReply(writer, statute.RepCommandNotSupported, nil); err != nil {
+	if err := handler.SendReply(writer, statute.RepCommandNotSupported, nil); err != nil {
 		return fmt.Errorf("failed to send reply: %v", err)
 	}
 	return nil
 }
 
 // handleAssociate is used to handle a connect command
-func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request *Request) error {
+func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request *handler.Request) error {
 	// Attempt to connect
 	dial := sf.dial
 	if dial == nil {
@@ -188,7 +154,7 @@ func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request
 	}
 	bindLn, err := net.ListenUDP("udp", nil)
 	if err != nil {
-		if err := SendReply(writer, statute.RepServerFailure, nil); err != nil {
+		if err := handler.SendReply(writer, statute.RepServerFailure, nil); err != nil {
 			return fmt.Errorf("failed to send reply, %v", err)
 		}
 		return fmt.Errorf("listen udp failed, %v", err)
@@ -196,7 +162,7 @@ func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request
 
 	sf.logger.Errorf("client want to used addr %v, listen addr: %s", request.DestAddr, bindLn.LocalAddr())
 	// send BND.ADDR and BND.PORT, client used
-	if err = SendReply(writer, statute.RepSuccess, bindLn.LocalAddr()); err != nil {
+	if err = handler.SendReply(writer, statute.RepSuccess, bindLn.LocalAddr()); err != nil {
 		return fmt.Errorf("failed to send reply, %v", err)
 	}
 
@@ -206,12 +172,12 @@ func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request
 		bufPool := sf.bufferPool.Get()
 		defer func() {
 			sf.bufferPool.Put(bufPool)
-			bindLn.Close()// nolint: errcheck
+			bindLn.Close() // nolint: errcheck
 			conns.Range(func(key, value any) bool {
 				if connTarget, ok := value.(net.Conn); !ok {
 					sf.logger.Errorf("conns has illegal item %v:%v", key, value)
 				} else {
-					connTarget.Close()// nolint: errcheck
+					connTarget.Close() // nolint: errcheck
 				}
 				return true
 			})
@@ -250,7 +216,7 @@ func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request
 				sf.goFunc(func() {
 					bufPool := sf.bufferPool.Get()
 					defer func() {
-						targetNew.Close()// nolint: errcheck
+						targetNew.Close() // nolint: errcheck
 						conns.Delete(connKey)
 						sf.bufferPool.Put(bufPool)
 					}()
@@ -297,7 +263,7 @@ func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request
 		_, err := request.Reader.Read(buf[:cap(buf)])
 		// sf.logger.Errorf("read data from client %s, %d bytesm, err is %+v", request.RemoteAddr.String(), num, err)
 		if err != nil {
-			bindLn.Close()// nolint: errcheck
+			bindLn.Close() // nolint: errcheck
 			if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
 				return nil
 			}
@@ -306,53 +272,13 @@ func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request
 	}
 }
 
-// SendReply is used to send a reply message
-// rep: reply status see statute's statute file
-func SendReply(w io.Writer, rep uint8, bindAddr net.Addr) error {
-	rsp := statute.Reply{
-		Version:  statute.VersionSocks5,
-		Response: rep,
-		BndAddr: statute.AddrSpec{
-			AddrType: statute.ATYPIPv4,
-			IP:       net.IPv4zero,
-			Port:     0,
-		},
-	}
-
-	if rsp.Response == statute.RepSuccess {
-		if tcpAddr, ok := bindAddr.(*net.TCPAddr); ok && tcpAddr != nil {
-			rsp.BndAddr.IP = tcpAddr.IP
-			rsp.BndAddr.Port = tcpAddr.Port
-		} else if udpAddr, ok := bindAddr.(*net.UDPAddr); ok && udpAddr != nil {
-			rsp.BndAddr.IP = udpAddr.IP
-			rsp.BndAddr.Port = udpAddr.Port
-		} else {
-			rsp.Response = statute.RepAddrTypeNotSupported
-		}
-
-		if rsp.BndAddr.IP.To4() != nil {
-			rsp.BndAddr.AddrType = statute.ATYPIPv4
-		} else if rsp.BndAddr.IP.To16() != nil {
-			rsp.BndAddr.AddrType = statute.ATYPIPv6
-		}
-	}
-	// Send the message
-	_, err := w.Write(rsp.Bytes())
-	return err
-}
-
-type closeWriter interface {
-	CloseWrite() error
-}
-
-// Proxy is used to suffle data from src to destination, and sends errors
-// down a dedicated channel
+// Proxy is used to shuffle data between src and dst using the internal buffer pool.
 func (sf *Server) Proxy(dst io.Writer, src io.Reader) error {
 	buf := sf.bufferPool.Get()
 	defer sf.bufferPool.Put(buf)
 	_, err := io.CopyBuffer(dst, src, buf[:cap(buf)])
-	if tcpConn, ok := dst.(closeWriter); ok {
-		tcpConn.CloseWrite() //nolint: errcheck
+	if tcpConn, ok := dst.(interface{ CloseWrite() error }); ok {
+		tcpConn.CloseWrite() //nolint:errcheck
 	}
 	return err
 }

--- a/handler/proxy.go
+++ b/handler/proxy.go
@@ -1,0 +1,22 @@
+package handler
+
+import (
+	"io"
+)
+
+// Proxy copies data from src to dst using provided buffer.
+// It closes write side if supported.
+type closeWriter interface {
+	CloseWrite() error
+}
+
+func Proxy(dst io.Writer, src io.Reader, buf []byte) error {
+	if len(buf) == 0 {
+		buf = make([]byte, 32*1024)
+	}
+	_, err := io.CopyBuffer(dst, src, buf)
+	if cw, ok := dst.(closeWriter); ok {
+		cw.CloseWrite() //nolint:errcheck
+	}
+	return err
+}

--- a/handler/reply.go
+++ b/handler/reply.go
@@ -1,0 +1,47 @@
+package handler
+
+import (
+	"io"
+	"net"
+
+	"github.com/things-go/go-socks5/statute"
+)
+
+// SendReply is used to send a reply message.
+// rep: reply status defined in statute package.
+func SendReply(w io.Writer, rep uint8, bindAddr net.Addr) error {
+	rsp := statute.Reply{
+		Version:  statute.VersionSocks5,
+		Response: rep,
+		BndAddr: statute.AddrSpec{
+			AddrType: statute.ATYPIPv4,
+			IP:       net.IPv4zero,
+			Port:     0,
+		},
+	}
+
+	if rsp.Response == statute.RepSuccess {
+		switch addr := bindAddr.(type) {
+		case *net.TCPAddr:
+			if addr != nil {
+				rsp.BndAddr.IP = addr.IP
+				rsp.BndAddr.Port = addr.Port
+			}
+		case *net.UDPAddr:
+			if addr != nil {
+				rsp.BndAddr.IP = addr.IP
+				rsp.BndAddr.Port = addr.Port
+			}
+		default:
+			rsp.Response = statute.RepAddrTypeNotSupported
+		}
+
+		if rsp.BndAddr.IP.To4() != nil {
+			rsp.BndAddr.AddrType = statute.ATYPIPv4
+		} else if rsp.BndAddr.IP.To16() != nil {
+			rsp.BndAddr.AddrType = statute.ATYPIPv6
+		}
+	}
+	_, err := w.Write(rsp.Bytes())
+	return err
+}

--- a/handler/request.go
+++ b/handler/request.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"context"
+	"io"
+	"net"
+
+	"github.com/things-go/go-socks5/statute"
+)
+
+// AddressRewriter is used to rewrite a destination transparently
+// returned context and dest address.
+type AddressRewriter interface {
+	Rewrite(ctx context.Context, request *Request) (context.Context, *statute.AddrSpec)
+}
+
+// Request represents request received by a server
+// Derived from statute.Request and adds additional fields
+// like authentication context and addresses.
+type Request struct {
+	statute.Request
+	AuthContext interface{}
+	LocalAddr   net.Addr
+	RemoteAddr  net.Addr
+	DestAddr    *statute.AddrSpec
+	Reader      io.Reader
+	RawDestAddr *statute.AddrSpec
+}
+
+// ParseRequest creates a new Request from the tcp connection
+func ParseRequest(bufConn io.Reader) (*Request, error) {
+	hd, err := statute.ParseRequest(bufConn)
+	if err != nil {
+		return nil, err
+	}
+	return &Request{
+		Request:     hd,
+		RawDestAddr: &hd.DstAddr,
+		Reader:      bufConn,
+	}, nil
+}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -1,4 +1,4 @@
-package socks5
+package resolver
 
 import (
 	"context"

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/things-go/go-socks5/resolver"
 )
 
 func TestDNSResolver(t *testing.T) {
-	d := DNSResolver{}
+	d := resolver.DNSResolver{}
 	ctx := context.Background()
 
 	_, addr, err := d.Resolve(ctx, "localhost")

--- a/rule/ruleset.go
+++ b/rule/ruleset.go
@@ -1,14 +1,15 @@
-package socks5
+package rule
 
 import (
 	"context"
 
+	"github.com/things-go/go-socks5/handler"
 	"github.com/things-go/go-socks5/statute"
 )
 
 // RuleSet is used to provide custom rules to allow or prohibit actions
 type RuleSet interface {
-	Allow(ctx context.Context, req *Request) (context.Context, bool)
+	Allow(ctx context.Context, req *handler.Request) (context.Context, bool)
 }
 
 // PermitCommand is an implementation of the RuleSet which
@@ -35,7 +36,7 @@ func NewPermitConnAndAss() RuleSet {
 }
 
 // Allow implement interface RuleSet
-func (p *PermitCommand) Allow(ctx context.Context, req *Request) (context.Context, bool) {
+func (p *PermitCommand) Allow(ctx context.Context, req *handler.Request) (context.Context, bool) {
 	switch req.Command {
 	case statute.CommandConnect:
 		return ctx, p.EnableConnect

--- a/ruleset_test.go
+++ b/ruleset_test.go
@@ -6,42 +6,44 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/things-go/go-socks5/handler"
+	"github.com/things-go/go-socks5/rule"
 	"github.com/things-go/go-socks5/statute"
 )
 
 func TestPermitCommand(t *testing.T) {
-	var r RuleSet
+	var r rule.RuleSet
 	var ok bool
 
 	ctx := context.Background()
 
-	r = NewPermitAll()
-	_, ok = r.Allow(ctx, &Request{Request: statute.Request{Command: statute.CommandConnect}})
+	r = rule.NewPermitAll()
+	_, ok = r.Allow(ctx, &handler.Request{Request: statute.Request{Command: statute.CommandConnect}})
 	require.True(t, ok)
-	_, ok = r.Allow(ctx, &Request{Request: statute.Request{Command: statute.CommandBind}})
+	_, ok = r.Allow(ctx, &handler.Request{Request: statute.Request{Command: statute.CommandBind}})
 	require.True(t, ok)
-	_, ok = r.Allow(ctx, &Request{Request: statute.Request{Command: statute.CommandAssociate}})
+	_, ok = r.Allow(ctx, &handler.Request{Request: statute.Request{Command: statute.CommandAssociate}})
 	require.True(t, ok)
-	_, ok = r.Allow(ctx, &Request{Request: statute.Request{Command: 0x00}})
+	_, ok = r.Allow(ctx, &handler.Request{Request: statute.Request{Command: 0x00}})
 	require.False(t, ok)
 
-	r = NewPermitConnAndAss()
-	_, ok = r.Allow(ctx, &Request{Request: statute.Request{Command: statute.CommandConnect}})
+	r = rule.NewPermitConnAndAss()
+	_, ok = r.Allow(ctx, &handler.Request{Request: statute.Request{Command: statute.CommandConnect}})
 	require.True(t, ok)
-	_, ok = r.Allow(ctx, &Request{Request: statute.Request{Command: statute.CommandBind}})
+	_, ok = r.Allow(ctx, &handler.Request{Request: statute.Request{Command: statute.CommandBind}})
 	require.False(t, ok)
-	_, ok = r.Allow(ctx, &Request{Request: statute.Request{Command: statute.CommandAssociate}})
+	_, ok = r.Allow(ctx, &handler.Request{Request: statute.Request{Command: statute.CommandAssociate}})
 	require.True(t, ok)
-	_, ok = r.Allow(ctx, &Request{Request: statute.Request{Command: 0x00}})
+	_, ok = r.Allow(ctx, &handler.Request{Request: statute.Request{Command: 0x00}})
 	require.False(t, ok)
 
-	r = NewPermitNone()
-	_, ok = r.Allow(ctx, &Request{Request: statute.Request{Command: statute.CommandConnect}})
+	r = rule.NewPermitNone()
+	_, ok = r.Allow(ctx, &handler.Request{Request: statute.Request{Command: statute.CommandConnect}})
 	require.False(t, ok)
-	_, ok = r.Allow(ctx, &Request{Request: statute.Request{Command: statute.CommandBind}})
+	_, ok = r.Allow(ctx, &handler.Request{Request: statute.Request{Command: statute.CommandBind}})
 	require.False(t, ok)
-	_, ok = r.Allow(ctx, &Request{Request: statute.Request{Command: statute.CommandAssociate}})
+	_, ok = r.Allow(ctx, &handler.Request{Request: statute.Request{Command: statute.CommandAssociate}})
 	require.False(t, ok)
-	_, ok = r.Allow(ctx, &Request{Request: statute.Request{Command: 0x00}})
+	_, ok = r.Allow(ctx, &handler.Request{Request: statute.Request{Command: 0x00}})
 	require.False(t, ok)
 }

--- a/server.go
+++ b/server.go
@@ -10,7 +10,11 @@ import (
 	"log"
 	"net"
 
+	"github.com/things-go/go-socks5/auth"
 	"github.com/things-go/go-socks5/bufferpool"
+	"github.com/things-go/go-socks5/handler"
+	"github.com/things-go/go-socks5/resolver"
+	"github.com/things-go/go-socks5/rule"
 	"github.com/things-go/go-socks5/statute"
 )
 
@@ -25,21 +29,21 @@ type Server struct {
 	// authMethods can be provided to implement authentication
 	// By default, "no-auth" mode is enabled.
 	// For password-based auth use UserPassAuthenticator.
-	authMethods []Authenticator
+	authMethods []auth.Authenticator
 	// If provided, username/password authentication is enabled,
 	// by appending a UserPassAuthenticator to AuthMethods. If not provided,
 	// and authMethods is nil, then "no-auth" mode is enabled.
-	credentials CredentialStore
+	credentials auth.CredentialStore
 	// resolver can be provided to do custom name resolution.
 	// Defaults to DNSResolver if not provided.
-	resolver NameResolver
+	resolver resolver.NameResolver
 	// rules is provided to enable custom logic around permitting
 	// various commands. If not provided, NewPermitAll is used.
-	rules RuleSet
+	rules rule.RuleSet
 	// rewriter can be used to transparently rewrite addresses.
 	// This is invoked before the RuleSet is invoked.
 	// Defaults to NoRewrite.
-	rewriter AddressRewriter
+	rewriter handler.AddressRewriter
 	// bindIP is used for bind or udp associate
 	bindIP net.IP
 	// logger can be used to provide a custom log target.
@@ -49,15 +53,15 @@ type Server struct {
 	// The callback set by dialWithRequest will be called first.
 	dial func(ctx context.Context, network, addr string) (net.Conn, error)
 	// Optional function for dialing out with the access of request detail.
-	dialWithRequest func(ctx context.Context, network, addr string, request *Request) (net.Conn, error)
+	dialWithRequest func(ctx context.Context, network, addr string, request *handler.Request) (net.Conn, error)
 	// buffer pool
 	bufferPool bufferpool.BufPool
 	// goroutine pool
 	gPool GPool
 	// user's handle
-	userConnectHandle   func(ctx context.Context, writer io.Writer, request *Request) error
-	userBindHandle      func(ctx context.Context, writer io.Writer, request *Request) error
-	userAssociateHandle func(ctx context.Context, writer io.Writer, request *Request) error
+	userConnectHandle   func(ctx context.Context, writer io.Writer, request *handler.Request) error
+	userBindHandle      func(ctx context.Context, writer io.Writer, request *handler.Request) error
+	userAssociateHandle func(ctx context.Context, writer io.Writer, request *handler.Request) error
 	// user's middleware
 	userConnectMiddlewares   MiddlewareChain
 	userBindMiddlewares      MiddlewareChain
@@ -67,10 +71,10 @@ type Server struct {
 // NewServer creates a new Server
 func NewServer(opts ...Option) *Server {
 	srv := &Server{
-		authMethods: []Authenticator{},
+		authMethods: []auth.Authenticator{},
 		bufferPool:  bufferpool.NewPool(32 * 1024),
-		resolver:    DNSResolver{},
-		rules:       NewPermitAll(),
+		resolver:    resolver.DNSResolver{},
+		rules:       rule.NewPermitAll(),
 		logger:      NewLogger(log.New(io.Discard, "socks5: ", log.LstdFlags)),
 	}
 
@@ -80,10 +84,10 @@ func NewServer(opts ...Option) *Server {
 
 	// Ensure we have at least one authentication method enabled
 	if (len(srv.authMethods) == 0) && srv.credentials != nil {
-		srv.authMethods = []Authenticator{&UserPassAuthenticator{srv.credentials}}
+		srv.authMethods = []auth.Authenticator{&auth.UserPassAuthenticator{Credentials: srv.credentials}}
 	}
 	if len(srv.authMethods) == 0 {
-		srv.authMethods = []Authenticator{&NoAuthAuthenticator{}}
+		srv.authMethods = []auth.Authenticator{&auth.NoAuthAuthenticator{}}
 	}
 
 	return srv
@@ -109,7 +113,7 @@ func (sf *Server) ListenAndServeTLS(network, addr string, c *tls.Config) error {
 
 // Serve is used to serve connections from a listener
 func (sf *Server) Serve(l net.Listener) error {
-	defer l.Close()// nolint: errcheck
+	defer l.Close() // nolint: errcheck
 	for {
 		conn, err := l.Accept()
 		if err != nil {
@@ -125,9 +129,9 @@ func (sf *Server) Serve(l net.Listener) error {
 
 // ServeConn is used to serve a single connection.
 func (sf *Server) ServeConn(conn net.Conn) error {
-	var authContext *AuthContext
+	var authContext *auth.AuthContext
 
-	defer conn.Close()// nolint: errcheck
+	defer conn.Close() // nolint: errcheck
 
 	bufConn := bufio.NewReader(conn)
 
@@ -150,10 +154,10 @@ func (sf *Server) ServeConn(conn net.Conn) error {
 	}
 
 	// The client request detail
-	request, err := ParseRequest(bufConn)
+	request, err := handler.ParseRequest(bufConn)
 	if err != nil {
 		if errors.Is(err, statute.ErrUnrecognizedAddrType) {
-			if err := SendReply(conn, statute.RepAddrTypeNotSupported, nil); err != nil {
+			if err := handler.SendReply(conn, statute.RepAddrTypeNotSupported, nil); err != nil {
 				return fmt.Errorf("failed to send reply %w", err)
 			}
 		}
@@ -163,7 +167,7 @@ func (sf *Server) ServeConn(conn net.Conn) error {
 	if request.Request.Command != statute.CommandConnect && // nolint: staticcheck
 		request.Request.Command != statute.CommandBind && // nolint: staticcheck
 		request.Request.Command != statute.CommandAssociate { // nolint: staticcheck
-		if err := SendReply(conn, statute.RepCommandNotSupported, nil); err != nil {
+		if err := handler.SendReply(conn, statute.RepCommandNotSupported, nil); err != nil {
 			return fmt.Errorf("failed to send reply, %v", err)
 		}
 		return fmt.Errorf("unrecognized command[%d]", request.Request.Command) // nolint: staticcheck
@@ -178,7 +182,7 @@ func (sf *Server) ServeConn(conn net.Conn) error {
 
 // authenticate is used to handle connection authentication
 func (sf *Server) authenticate(conn io.Writer, bufConn io.Reader,
-	userAddr string, methods []byte) (*AuthContext, error) {
+	userAddr string, methods []byte) (*auth.AuthContext, error) {
 	// Select a usable method
 	for _, auth := range sf.authMethods {
 		for _, method := range methods {

--- a/server_test.go
+++ b/server_test.go
@@ -40,11 +40,11 @@ func TestSOCKS5_Connect(t *testing.T) {
 		lAddr := l.Addr().(*net.TCPAddr)
 
 		// Create a socks server with UserPass auth.
-		cator := UserPassAuthenticator{StaticCredentials{"foo": "bar"}}
+		cator := auth.UserPassAuthenticator{Credentials: auth.StaticCredentials{"foo": "bar"}}
 		srv := NewServer(
-			WithAuthMethods([]Authenticator{cator}),
+			WithAuthMethods([]auth.Authenticator{cator}),
 			WithLogger(NewLogger(log.New(os.Stdout, "socks5: ", log.LstdFlags))),
-			WithDialAndRequest(func(ctx context.Context, network, addr string, request *Request) (net.Conn, error) {
+			WithDialAndRequest(func(ctx context.Context, network, addr string, request *handler.Request) (net.Conn, error) {
 				require.Equal(t, network, "tcp")
 				require.Equal(t, addr, lAddr.String())
 				return net.Dial(network, addr)
@@ -136,16 +136,16 @@ func TestSOCKS5_Connect(t *testing.T) {
 		lAddr := l.Addr().(*net.TCPAddr)
 
 		// Create a socks server with UserPass auth.
-		cator := UserPassAuthenticator{StaticCredentials{"foo": "bar"}}
+		cator := auth.UserPassAuthenticator{Credentials: auth.StaticCredentials{"foo": "bar"}}
 		srv := NewServer(
-			WithAuthMethods([]Authenticator{cator}),
+			WithAuthMethods([]auth.Authenticator{cator}),
 			WithLogger(NewLogger(log.New(os.Stdout, "socks5: ", log.LstdFlags))),
-			WithDialAndRequest(func(ctx context.Context, network, addr string, request *Request) (net.Conn, error) {
+			WithDialAndRequest(func(ctx context.Context, network, addr string, request *handler.Request) (net.Conn, error) {
 				require.Equal(t, network, "tcp")
 				require.Equal(t, addr, lAddr.String())
 				return net.Dial(network, addr)
 			}),
-			WithConnectHandle(func(ctx context.Context, writer io.Writer, request *Request) error {
+			WithConnectHandle(func(ctx context.Context, writer io.Writer, request *handler.Request) error {
 				rsp := statute.Reply{
 					Version:  statute.VersionSocks5,
 					Response: 0x00,
@@ -252,16 +252,16 @@ func TestSOCKS5_Connect(t *testing.T) {
 		lAddr := l.Addr().(*net.TCPAddr)
 
 		// Create a socks server with UserPass auth.
-		cator := UserPassAuthenticator{StaticCredentials{"foo": "bar"}}
+		cator := auth.UserPassAuthenticator{Credentials: auth.StaticCredentials{"foo": "bar"}}
 		srv := NewServer(
-			WithAuthMethods([]Authenticator{cator}),
+			WithAuthMethods([]auth.Authenticator{cator}),
 			WithLogger(NewLogger(log.New(os.Stdout, "socks5: ", log.LstdFlags))),
-			WithDialAndRequest(func(ctx context.Context, network, addr string, request *Request) (net.Conn, error) {
+			WithDialAndRequest(func(ctx context.Context, network, addr string, request *handler.Request) (net.Conn, error) {
 				require.Equal(t, network, "tcp")
 				require.Equal(t, addr, lAddr.String())
 				return net.Dial(network, addr)
 			}),
-			WithConnectMiddleware(func(ctx context.Context, writer io.Writer, request *Request) error {
+			WithConnectMiddleware(func(ctx context.Context, writer io.Writer, request *handler.Request) error {
 				middlewareCalled = true
 				require.Equal(t, request.LocalAddr.String(), `127.0.0.1:12366`)
 				return nil
@@ -356,16 +356,16 @@ func TestSOCKS5_Connect(t *testing.T) {
 		lAddr := l.Addr().(*net.TCPAddr)
 
 		// Create a socks server with UserPass auth.
-		cator := UserPassAuthenticator{StaticCredentials{"foo": "bar"}}
+		cator := auth.UserPassAuthenticator{Credentials: auth.StaticCredentials{"foo": "bar"}}
 		srv := NewServer(
-			WithAuthMethods([]Authenticator{cator}),
+			WithAuthMethods([]auth.Authenticator{cator}),
 			WithLogger(NewLogger(log.New(os.Stdout, "socks5: ", log.LstdFlags))),
-			WithDialAndRequest(func(ctx context.Context, network, addr string, request *Request) (net.Conn, error) {
+			WithDialAndRequest(func(ctx context.Context, network, addr string, request *handler.Request) (net.Conn, error) {
 				require.Equal(t, network, "tcp")
 				require.Equal(t, addr, lAddr.String())
 				return net.Dial(network, addr)
 			}),
-			WithConnectMiddleware(func(ctx context.Context, writer io.Writer, request *Request) error {
+			WithConnectMiddleware(func(ctx context.Context, writer io.Writer, request *handler.Request) error {
 				middlewareCalled = true
 				require.Equal(t, request.LocalAddr.String(), `127.0.0.1:12367`)
 				return errors.New("Address is blocked!")
@@ -464,9 +464,9 @@ func TestSOCKS5_Associate(t *testing.T) {
 		defer client.Close() // nolint: errcheck
 
 		// Create a socks server
-		cator := UserPassAuthenticator{StaticCredentials{"foo": "bar"}}
+		cator := auth.UserPassAuthenticator{Credentials: auth.StaticCredentials{"foo": "bar"}}
 		proxySrv := NewServer(
-			WithAuthMethods([]Authenticator{cator}),
+			WithAuthMethods([]auth.Authenticator{cator}),
 			WithLogger(NewLogger(log.New(os.Stdout, "socks5: ", log.LstdFlags))),
 		)
 		// Start listening
@@ -565,11 +565,11 @@ func TestSOCKS5_Associate(t *testing.T) {
 		defer client.Close() // nolint: errcheck
 
 		// Create a socks server
-		cator := UserPassAuthenticator{StaticCredentials{"foo": "bar"}}
+		cator := auth.UserPassAuthenticator{Credentials: auth.StaticCredentials{"foo": "bar"}}
 		proxySrv := NewServer(
-			WithAuthMethods([]Authenticator{cator}),
+			WithAuthMethods([]auth.Authenticator{cator}),
 			WithLogger(NewLogger(log.New(os.Stdout, "socks5: ", log.LstdFlags))),
-			WithAssociateMiddleware(func(ctx context.Context, writer io.Writer, request *Request) error {
+			WithAssociateMiddleware(func(ctx context.Context, writer io.Writer, request *handler.Request) error {
 				require.Equal(t, request.DestAddr.Port, 12499)
 				middlewareCalled = true
 				return nil
@@ -664,9 +664,9 @@ func Test_SocksWithProxy(t *testing.T) {
 	lAddr := l.Addr().(*net.TCPAddr)
 
 	// Create a socks server with UserPass auth.
-	cator := UserPassAuthenticator{StaticCredentials{"foo": "bar"}}
+	cator := auth.UserPassAuthenticator{Credentials: auth.StaticCredentials{"foo": "bar"}}
 	serv := NewServer(
-		WithAuthMethods([]Authenticator{cator}),
+		WithAuthMethods([]auth.Authenticator{cator}),
 		WithLogger(NewLogger(log.New(os.Stdout, "socks5: ", log.LstdFlags))),
 	)
 	// Start socks server
@@ -700,7 +700,7 @@ func Test_SocksWithProxy(t *testing.T) {
 func TestNoAuth_Server(t *testing.T) {
 	req := bytes.NewBuffer(nil)
 	rsp := new(bytes.Buffer)
-	s := NewServer(WithAuthMethods([]Authenticator{&NoAuthAuthenticator{}}))
+	s := NewServer(WithAuthMethods([]auth.Authenticator{&auth.NoAuthAuthenticator{}}))
 
 	ctx, err := s.authenticate(rsp, req, "", []byte{statute.MethodNoAuth})
 	require.NoError(t, err)
@@ -711,10 +711,10 @@ func TestNoAuth_Server(t *testing.T) {
 func TestPasswordAuth_Valid_Server(t *testing.T) {
 	req := bytes.NewBuffer([]byte{1, 3, 'f', 'o', 'o', 3, 'b', 'a', 'r'})
 	rsp := new(bytes.Buffer)
-	cator := UserPassAuthenticator{
-		StaticCredentials{"foo": "bar"},
+	cator := auth.UserPassAuthenticator{
+		Credentials: auth.StaticCredentials{"foo": "bar"},
 	}
-	s := NewServer(WithAuthMethods([]Authenticator{cator}))
+	s := NewServer(WithAuthMethods([]auth.Authenticator{cator}))
 
 	ctx, err := s.authenticate(rsp, req, "", []byte{statute.MethodUserPassAuth})
 	require.NoError(t, err)
@@ -734,10 +734,10 @@ func TestPasswordAuth_Valid_Server(t *testing.T) {
 func TestPasswordAuth_Invalid_Server(t *testing.T) {
 	req := bytes.NewBuffer([]byte{1, 3, 'f', 'o', 'o', 3, 'b', 'a', 'z'})
 	rsp := new(bytes.Buffer)
-	cator := UserPassAuthenticator{
-		StaticCredentials{"foo": "bar"},
+	cator := auth.UserPassAuthenticator{
+		Credentials: auth.StaticCredentials{"foo": "bar"},
 	}
-	s := NewServer(WithAuthMethods([]Authenticator{cator}))
+	s := NewServer(WithAuthMethods([]auth.Authenticator{cator}))
 
 	ctx, err := s.authenticate(rsp, req, "", []byte{statute.MethodNoAuth, statute.MethodUserPassAuth})
 	require.True(t, errors.Is(err, statute.ErrUserAuthFailed))
@@ -749,11 +749,11 @@ func TestPasswordAuth_Invalid_Server(t *testing.T) {
 func TestNoSupportedAuth_Server(t *testing.T) {
 	req := bytes.NewBuffer(nil)
 	rsp := new(bytes.Buffer)
-	cator := UserPassAuthenticator{
-		StaticCredentials{"foo": "bar"},
+	cator := auth.UserPassAuthenticator{
+		Credentials: auth.StaticCredentials{"foo": "bar"},
 	}
 
-	s := NewServer(WithAuthMethods([]Authenticator{cator}))
+	s := NewServer(WithAuthMethods([]auth.Authenticator{cator}))
 
 	ctx, err := s.authenticate(rsp, req, "", []byte{statute.MethodNoAuth})
 	require.True(t, errors.Is(err, statute.ErrNoSupportedAuth))


### PR DESCRIPTION
## Summary
- move authentication logic to `auth` package
- add `handler` helpers for requests, replies, and proxying
- move resolver code to its own package
- move rule logic to its own package
- update server to wire new packages

## Testing
- `go test ./...` *(fails: failed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_684c3764cf9c832aa6701117e8a4a894