### PR TITLE
Add caching resolver and context-aware DNS lookups

### DIFF
--- a/resolver/cache.go
+++ b/resolver/cache.go
@@ -1,0 +1,59 @@
+package resolver
+
+import (
+	"context"
+	"net"
+	"sync"
+	"time"
+)
+
+type cachingEntry struct {
+	ip      net.IP
+	expires time.Time
+}
+
+// CachingResolver wraps another NameResolver and caches results
+// for a configurable TTL.
+type CachingResolver struct {
+	resolver NameResolver
+	ttl      time.Duration
+	mu       sync.Mutex
+	cache    map[string]cachingEntry
+}
+
+// NewCachingResolver creates a resolver that caches DNS lookups.
+// If the provided resolver is nil, DNSResolver is used.
+func NewCachingResolver(res NameResolver, ttl time.Duration) *CachingResolver {
+	if res == nil {
+		res = DNSResolver{}
+	}
+	return &CachingResolver{
+		resolver: res,
+		ttl:      ttl,
+		cache:    make(map[string]cachingEntry),
+	}
+}
+
+// Resolve resolves the name and caches the result until the TTL expires.
+func (c *CachingResolver) Resolve(ctx context.Context, name string) (context.Context, net.IP, error) {
+	now := time.Now()
+	c.mu.Lock()
+	if entry, ok := c.cache[name]; ok && now.Before(entry.expires) {
+		ip := make(net.IP, len(entry.ip))
+		copy(ip, entry.ip)
+		c.mu.Unlock()
+		return ctx, ip, nil
+	}
+	c.mu.Unlock()
+
+	ctx, ip, err := c.resolver.Resolve(ctx, name)
+	if err != nil {
+		return ctx, ip, err
+	}
+
+	c.mu.Lock()
+	c.cache[name] = cachingEntry{ip: ip, expires: now.Add(c.ttl)}
+	c.mu.Unlock()
+
+	return ctx, ip, nil
+}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"context"
+	"fmt"
 	"net"
 )
 
@@ -15,9 +16,12 @@ type DNSResolver struct{}
 
 // Resolve implement interface NameResolver
 func (d DNSResolver) Resolve(ctx context.Context, name string) (context.Context, net.IP, error) {
-	addr, err := net.ResolveIPAddr("ip", name)
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", name)
 	if err != nil {
 		return ctx, nil, err
 	}
-	return ctx, addr.IP, err
+	if len(ips) == 0 {
+		return ctx, nil, fmt.Errorf("no ip returned for %s", name)
+	}
+	return ctx, ips[0], nil
 }

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -2,10 +2,14 @@ package socks5
 
 import (
 	"context"
+	"net"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/things-go/go-socks5/resolver"
 )
 
@@ -16,4 +20,35 @@ func TestDNSResolver(t *testing.T) {
 	_, addr, err := d.Resolve(ctx, "localhost")
 	require.NoError(t, err)
 	assert.True(t, addr.IsLoopback())
+}
+
+type mockResolver struct {
+	mu    sync.Mutex
+	count int
+}
+
+func (m *mockResolver) Resolve(ctx context.Context, name string) (context.Context, net.IP, error) {
+	m.mu.Lock()
+	m.count++
+	m.mu.Unlock()
+	return ctx, net.IPv4(127, 0, 0, 1), nil
+}
+
+func TestCachingResolver(t *testing.T) {
+	base := &mockResolver{}
+	c := resolver.NewCachingResolver(base, 50*time.Millisecond)
+	ctx := context.Background()
+
+	_, ip1, err := c.Resolve(ctx, "localhost")
+	require.NoError(t, err)
+	assert.True(t, ip1.IsLoopback())
+
+	_, ip2, err := c.Resolve(ctx, "localhost")
+	require.NoError(t, err)
+	assert.True(t, ip2.Equal(ip1))
+	assert.Equal(t, 1, base.count)
+
+	time.Sleep(60 * time.Millisecond)
+	_, _, _ = c.Resolve(ctx, "localhost")
+	assert.Equal(t, 2, base.count)
 }


### PR DESCRIPTION
## Summary
- improve `DNSResolver` to use `net.DefaultResolver` with context
- add `CachingResolver` with TTL-based cache
- add tests for the new caching resolver

## Testing
- `go test ./...` *(fails: download dependencies blocked)*

------
https://chatgpt.com/codex/tasks/task_b_684c464b283c832a84db0d17d147f43c